### PR TITLE
Fix table border when missing RepoURL and License

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,8 @@ func (ds *deps) getLicensesWriteStd(apiKeys map[string]string, fw bool) {
 				continue
 			}
 			str = append(str, color.BlueString(v.license.URL), v.license.Shortname)
+		} else {
+			str = append(str, "", "")
 		}
 		table.Append(str)
 	}

--- a/main.go
+++ b/main.go
@@ -203,14 +203,15 @@ func (ds *deps) getLicensesWriteStd(apiKeys map[string]string, fw bool) {
 	}
 	for _, v := range ds.deps {
 		str := []string{v.name, strconv.Itoa(v.count + 1)}
-		if v.license != nil && !v.license.Exists {
+		switch {
+		case v.license != nil && !v.license.Exists:
 			keepdir = true
 			err := v.license.GetLicenses(c, apiKeys, fw)
 			if err != nil {
 				continue
 			}
 			str = append(str, color.BlueString(v.license.URL), v.license.Shortname)
-		} else {
+		default:
 			str = append(str, "", "")
 		}
 		table.Append(str)


### PR DESCRIPTION
As you see below, the table seems incongruous that several rows miss table border.
```
+-----------------------------------+-------+-------------------------------------------+--------------+
|            DEPENDENCY             | COUNT |                  REPOURL                  |   LICENSE    |
+-----------------------------------+-------+-------------------------------------------+--------------+
| github.com/fatih/color            |     2 | https://github.com/fatih/color            | MIT          |
| github.com/olekukonko/tablewriter |     1 | https://github.com/olekukonko/tablewriter | MIT          |
| github.com/google/go-github       |     1 | https://github.com/google/go-github       | Other        |
| golang.org/x/oauth2               |     1 |                                                           
| github.com/markbates/going        |     2 | https://github.com/markbates/going        | MIT          |
| gopkg.in/gomail.v2                |     1 |                                                           
| gopkg.in/guregu/null.v3           |     1 | https://github.com/guregu/null            | bsd-2-clause |
| github.com/serenize/snaker        |     1 | https://github.com/serenize/snaker        | MIT          |
+-----------------------------------+-------+-------------------------------------------+--------------+
```