### PR TITLE
Revert error checking on mkdir

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,10 +236,7 @@ func (ds *deps) writeLicensesToFile(path string) error {
 		return nil
 	}
 
-	err := os.Mkdir(licenseDir, 0777)
-	if err != nil {
-		return err
-	}
+	os.Mkdir(licenseDir, 0777)
 
 	for _, v := range ds.deps {
 		if v.repo.Text == "" {


### PR DESCRIPTION
Revert error checking made in #19, in order to allow mkdir to fail gracefully when folder already exists.

Totally spaced on that. Saw it just as the other PR got merged.